### PR TITLE
Hotfix: Stress Tensor Fix for vasp2xyzf and cp2k_to_xyzf

### DIFF
--- a/src/cp2k_to_xyz.py
+++ b/src/cp2k_to_xyz.py
@@ -27,7 +27,8 @@ def cp2k_to_xyzf(xyzfile, outfile, forcefile, argv):
                 store += 1
             if store > 3:
                 store = -1
-                tensors.append(tensor[0] + tensor[1] + tensor[2]) # Already in GPa
+                # Output form should be xx,yy,zz,xy,xz,yz
+                tensors.append([tensor[0][0]] + [tensor[1][1]] + [tensor[2][2]] + [tensor[0][1]] + [tensor[0][2]] + [tensor[1][2]]) # Already in GPa
                 tensor = []
     
     # Store the cell vectors
@@ -48,8 +49,8 @@ def cp2k_to_xyzf(xyzfile, outfile, forcefile, argv):
     
     crdstream = open(xyzfile,  'r')
     frcstream = open(forcefile,'r')
-    xyzfstream = xyzfile.split(".xyz.xyz")
-    xyzfstream = ''.join(xyzfstream) + ".xyz.xyzf"
+    xyzfstream = xyzfile.split(".xyz")
+    xyzfstream = ''.join(xyzfstream) + ".xyzf"
     xyzfstream = open(xyzfstream,'w')
 
     natoms = int(helpers.head(xyzfile,1)[0])
@@ -64,11 +65,11 @@ def cp2k_to_xyzf(xyzfile, outfile, forcefile, argv):
         boxline = ' '.join(cell)
            
         if "ALLSTR" in argv:
-            boxline = boxline + ' '.join(tensors[f]) + " "
+            boxline = boxline + " " +  ' '.join(tensors[f])
         elif "STRESS" in argv:
-            boxline = boxline + ' '.join(tensors[f][0:3]) + " "
+            boxline = boxline + " " +' '.join(tensors[f][0:3])
         if "ENERGY" in argv:
-            boxline  = boxline + str(energies[f])
+            boxline  = boxline + " " + str(energies[f])
         
         xyzfstream.write("NON_ORTHO " + boxline + '\n')
         

--- a/src/dftbplus_driver.py
+++ b/src/dftbplus_driver.py
@@ -301,7 +301,7 @@ def check_convergence(my_ALC, *argv, **kwargs):
     
     return  total_failed
 
-def generate_gen(inxyz, *argv):
+def generate_gen(inxyz, *argv, **kwargs):
 
     """ 
     
@@ -309,17 +309,25 @@ def generate_gen(inxyz, *argv):
     
     Usage: (my_file./usr/workspace/wsb/rlindsey/AL_Driver_SVN/rlindsey_branch/xyz, ["C","O"], 6500) # , [1,2])
     
-    Notes: The second argument is list of atom types
+    Notes: The second required argument is list of atom types
            The final argument is the smearing temperature, in Kelvin
-              
+           The optional argument is to sort or not sort the atoms
     """
 
-    atm_types = argv[0] # pointer!
-    smearing  = float(argv[1])
-    ifstream  = open(inxyz,'r')
-    ofstream  = open(inxyz + ".gen", 'w')
+    ### **kwargs
+    default_keys = [""]*1 
+    default_values = [""]*1 
+    # DFTB specific controls 
+    default_keys[0 ] = "do_sort" ; default_values[0 ] = True # Whether atom types should be sorted and excess element types removed 
+    args = dict(list(zip(default_keys, default_values))) 
+    args.update(kwargs)
     
-    # Set up the header portion
+    atm_types = argv[0] # pointer!
+    smearing = float(argv[1])
+    ifstream = open(inxyz,'r')
+    ofstream = open(inxyz + ".gen", 'w')
+    
+   # Set up the header portion
         
     box = ifstream.readline()        # No. atoms
     box = ifstream.readline().split()    # Box lengths
@@ -345,7 +353,8 @@ def generate_gen(inxyz, *argv):
     # Count up the number of atoms of each type
     
     contents = ifstream.readlines()
-    contents.sort() # To remain constistent with all other QM methods that expects sorted coordinates
+    if args["do_sort"]:
+        contents.sort() # To remain constistent with all other QM methods that expects sorted coordinates
     
     natm_types = [0]*len(atm_types)
     
@@ -357,22 +366,23 @@ def generate_gen(inxyz, *argv):
                 
                 natm_types[j] += 1
                 
-    
+    if args["do_sort"]:
     # Remove any elements that don't appear in the coordinate file
     # But first, make sure everything is sorted 
+   
+        tmp = list(zip(atm_types,natm_types))
+        tmp.sort() # Sorts by the first entry (atom types) ... alphabetical
     
-    tmp = list(zip(atm_types,natm_types))
-    tmp.sort() # Sorts by the first entry (atom types) ... alphabetical
-    
-    for i in range(len(tmp)-1,-1,-1): # Goes through list backwards
+        for i in range(len(tmp)-1,-1,-1): # Goes through list backwards
         
-        if tmp[i][1] == 0: 
+            if tmp[i][1] == 0: 
         
-            tmp.pop(i)
+                tmp.pop(i)
     
-    atm_types  = list(list(zip(*tmp))[0])
-    natm_types = list(map(int,list(list(zip(*tmp))[1])))
-
+        atm_types  = list(list(zip(*tmp))[0])
+        natm_types = list(map(int,list(list(zip(*tmp))[1])))
+    else:
+        print('WARNING!!!: atom sorting and exess type removing is turned off')
     # Finish up the header portion
     
     ofstream.write(str(sum(natm_types)) + " S\n")
@@ -382,7 +392,7 @@ def generate_gen(inxyz, *argv):
     for i in range(len(contents)):
         
         line = contents[i].split()                
-        line = str(i+1) + " " + str(atm_types.index(line[0])+1) + " " +  ' '.join(line[1:]) + '\n'
+        line = str(i+1) + " " + str(atm_types.index(line[0])+1) + " " +  ' '.join(line[1:4]) + '\n'
         ofstream.write(line)
     
     ofstream.write("0.0 0.0 0.0\n")    

--- a/src/dftbplus_driver.py
+++ b/src/dftbplus_driver.py
@@ -301,7 +301,7 @@ def check_convergence(my_ALC, *argv, **kwargs):
     
     return  total_failed
 
-def generate_gen(inxyz, *argv, **kwargs):
+def generate_gen(inxyz, *argv):
 
     """ 
     
@@ -309,25 +309,17 @@ def generate_gen(inxyz, *argv, **kwargs):
     
     Usage: (my_file./usr/workspace/wsb/rlindsey/AL_Driver_SVN/rlindsey_branch/xyz, ["C","O"], 6500) # , [1,2])
     
-    Notes: The second required argument is list of atom types
+    Notes: The second argument is list of atom types
            The final argument is the smearing temperature, in Kelvin
-           The optional argument is to sort or not sort the atoms
+              
     """
 
-    ### **kwargs
-    default_keys = [""]*1 
-    default_values = [""]*1 
-    # DFTB specific controls 
-    default_keys[0 ] = "do_sort" ; default_values[0 ] = True # Whether atom types should be sorted and excess element types removed 
-    args = dict(list(zip(default_keys, default_values))) 
-    args.update(kwargs)
-    
     atm_types = argv[0] # pointer!
-    smearing = float(argv[1])
-    ifstream = open(inxyz,'r')
-    ofstream = open(inxyz + ".gen", 'w')
+    smearing  = float(argv[1])
+    ifstream  = open(inxyz,'r')
+    ofstream  = open(inxyz + ".gen", 'w')
     
-   # Set up the header portion
+    # Set up the header portion
         
     box = ifstream.readline()        # No. atoms
     box = ifstream.readline().split()    # Box lengths
@@ -353,8 +345,7 @@ def generate_gen(inxyz, *argv, **kwargs):
     # Count up the number of atoms of each type
     
     contents = ifstream.readlines()
-    if args["do_sort"]:
-        contents.sort() # To remain constistent with all other QM methods that expects sorted coordinates
+    contents.sort() # To remain constistent with all other QM methods that expects sorted coordinates
     
     natm_types = [0]*len(atm_types)
     
@@ -366,23 +357,22 @@ def generate_gen(inxyz, *argv, **kwargs):
                 
                 natm_types[j] += 1
                 
-    if args["do_sort"]:
+    
     # Remove any elements that don't appear in the coordinate file
     # But first, make sure everything is sorted 
-   
-        tmp = list(zip(atm_types,natm_types))
-        tmp.sort() # Sorts by the first entry (atom types) ... alphabetical
     
-        for i in range(len(tmp)-1,-1,-1): # Goes through list backwards
-        
-            if tmp[i][1] == 0: 
-        
-                tmp.pop(i)
+    tmp = list(zip(atm_types,natm_types))
+    tmp.sort() # Sorts by the first entry (atom types) ... alphabetical
     
-        atm_types  = list(list(zip(*tmp))[0])
-        natm_types = list(map(int,list(list(zip(*tmp))[1])))
-    else:
-        print('WARNING!!!: atom sorting and exess type removing is turned off')
+    for i in range(len(tmp)-1,-1,-1): # Goes through list backwards
+        
+        if tmp[i][1] == 0: 
+        
+            tmp.pop(i)
+    
+    atm_types  = list(list(zip(*tmp))[0])
+    natm_types = list(map(int,list(list(zip(*tmp))[1])))
+
     # Finish up the header portion
     
     ofstream.write(str(sum(natm_types)) + " S\n")
@@ -392,7 +382,7 @@ def generate_gen(inxyz, *argv, **kwargs):
     for i in range(len(contents)):
         
         line = contents[i].split()                
-        line = str(i+1) + " " + str(atm_types.index(line[0])+1) + " " +  ' '.join(line[1:4]) + '\n'
+        line = str(i+1) + " " + str(atm_types.index(line[0])+1) + " " +  ' '.join(line[1:]) + '\n'
         ofstream.write(line)
     
     ofstream.write("0.0 0.0 0.0\n")    
@@ -791,4 +781,3 @@ def setup_dftb(my_ALC, *argv, **kwargs):
         os.chdir(curr_dir)
     
     return run_dftb_jobid    
-

--- a/src/main.py
+++ b/src/main.py
@@ -790,7 +790,7 @@ def main(args):
                         job_account        = config.HPC_ACCOUNT, 
                         job_system         = config.HPC_SYSTEM,
                         job_executable     = config.CHIMES_SOLVER,
-                        job_modules        = config.CHIMES_MODULES
+                        job_modules        = config.CHIMES_LSQ_MODULES
                         )    
                     
                     helpers.wait_for_job(active_job, job_system = config.HPC_SYSTEM, verbose = True, job_name = "restart_solve_amat")

--- a/src/vasp2xyzf.py
+++ b/src/vasp2xyzf.py
@@ -269,7 +269,7 @@ for LINE in IFSTREAM:
             if INCL_STRESS:
                 OFSTREAM.write(" " +repr(TENSOR_XX)+ " " + repr(TENSOR_YY) + " " + repr(TENSOR_ZZ))
             elif INCL_ALLSTR:
-                OFSTREAM.write(" " +repr(TENSOR_XX)+ " " + repr(TENSOR_YY) + " " + repr(TENSOR_ZZ) + " " + repr(TENSOR_XY) + " " + repr(TENSOR_YZ) + " " + repr(TENSOR_ZX)) 
+                OFSTREAM.write(" " +repr(TENSOR_XX)+ " " + repr(TENSOR_YY) + " " + repr(TENSOR_ZZ) + " " + repr(TENSOR_XY) + " " + repr(TENSOR_ZX) + " " + repr(TENSOR_YZ)) 
             if INCL_ENERGY:
                 OFSTREAM.write(" " + repr(POT_ENER))
             OFSTREAM.write('\n')


### PR DESCRIPTION
Fix a bug about the loaded modules for config.py 
Fix the stress tensors ordering in cp2k_to_xyz and vasp2xyzf, to be consistent with what chimes_lsq.C expects. For refernece check ClassDefs.
Revert dftplus_driver to main version.

Note: This will change the output of the hierarchical example! (needs to be updated)