### PR TITLE
Job system conditionals for slurm and UM-ARC are changed and restart conditionals (URGENT FOR TACC)

### DIFF
--- a/src/chimes_run_md.py
+++ b/src/chimes_run_md.py
@@ -274,7 +274,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
     job_task  = "-n " + repr(int(args["job_nodes"])*int(args["job_ppn"])) + " " +  args["job_executable"] + " " + md_infile + " > run_md.out"    
     
-    if args["job_system"]  == "slurm" or "UM-ARC":
+    if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
         job_task = "srun "   + job_task
     elif args["job_system"] == "TACC":
         job_task = "ibrun "  + job_task

--- a/src/cp2k_driver.py
+++ b/src/cp2k_driver.py
@@ -166,7 +166,7 @@ def continue_job(*argv, **kwargs):
             
                 print("            Resubmitting.")
 
-                if args["job_system"] == "slurm" or "TACC" or "UM-ARC":
+                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
                     job_list.append(helpers.run_bash_cmnd("sbatch run_cp2k.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_cp2k.cmd").replace('\n', ''))

--- a/src/cp2k_driver.py
+++ b/src/cp2k_driver.py
@@ -166,7 +166,7 @@ def continue_job(*argv, **kwargs):
             
                 print("            Resubmitting.")
 
-                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
+                if args["job_system"] == "slurm" or args["job_system"] == "TACC" or args["job_system"] == "UM-ARC":
                     job_list.append(helpers.run_bash_cmnd("sbatch run_cp2k.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_cp2k.cmd").replace('\n', ''))

--- a/src/dftbplus_driver.py
+++ b/src/dftbplus_driver.py
@@ -164,7 +164,7 @@ def continue_job(*argv, **kwargs):
             
                 print("            Resubmitting.")
 
-                if args["job_system"] == "slurm" or "TACC" or "UM-ARC":
+                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
                     job_list.append(helpers.run_bash_cmnd("sbatch run_dftb.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_dftb.cmd").replace('\n', ''))

--- a/src/dftbplus_driver.py
+++ b/src/dftbplus_driver.py
@@ -164,7 +164,7 @@ def continue_job(*argv, **kwargs):
             
                 print("            Resubmitting.")
 
-                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
+                if args["job_system"] == "slurm" or args["job_system"] == "TACC" or args["job_system"] == "UM-ARC":
                     job_list.append(helpers.run_bash_cmnd("sbatch run_dftb.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_dftb.cmd").replace('\n', ''))

--- a/src/dftbplus_run_md.py
+++ b/src/dftbplus_run_md.py
@@ -292,7 +292,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
     job_task  = "-n 1 " + args["job_executable"] + " > dftb.out"    
 
-    if args["job_system"]  == "slurm" or "UM-ARC":
+    if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
         job_task = "srun "   + job_task
     elif args["job_system"] == "TACC":
         job_task = "ibrun "  + job_task

--- a/src/gen_ff.py
+++ b/src/gen_ff.py
@@ -1,4 +1,4 @@
-143526# Global (python) modules
+# Global (python) modules
 
 import os.path
 import os

--- a/src/gen_ff.py
+++ b/src/gen_ff.py
@@ -945,7 +945,7 @@ def build_amat(my_ALC, **kwargs):
         job_task = args["job_executable"] + " fm_setup.in | tee fm_setup.log"
         if int(args["n_hyper_sets"]) == 1:
             job_task = "-n " + repr(int(args["job_nodes"])*int(args["job_ppn"])) + " " + job_task
-        if args["job_system"] == "slurm"  or "UM-ARC" and int(args["n_hyper_sets"]) == 1:
+        if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC") and int(args["n_hyper_sets"]) == 1:
             job_task = "srun "   + job_task
         elif args["job_system"] == "TACC" and int(args["n_hyper_sets"]) == 1:
             job_task = "ibrun "   + job_task

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -595,7 +595,7 @@ def create_and_launch_job(*argv, **kwargs):
 
     jobid = None
     
-    if args["job_system"] == "slurm" or "TACC":
+    if args["job_system"] == "slurm" or args["job_system"] == "TACC" or args["job_system"] == "UM-ARC":
         jobid = run_bash_cmnd("sbatch " + args["job_file"]).split()[-1]
     else:    
         jobid = run_bash_cmnd("qsub " + args["job_file"])

--- a/src/lmp_run_md.py
+++ b/src/lmp_run_md.py
@@ -413,7 +413,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     job_task = ""
     
 
-    if args["job_system"] == "slurm" or "UM-ARC":
+    if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
         job_task += "srun -N "   + repr(int(args["job_nodes" ])) + " -n " + repr(int(args["job_nodes"])*int(args["job_ppn"])) + " "
     elif args["job_system"] == "TACC":
         job_task == "    ibrun " + "-n " + repr(int(args["job_nodes"])*int(args["job_ppn"])) + " "

--- a/src/vasp_driver.py
+++ b/src/vasp_driver.py
@@ -180,7 +180,7 @@ def continue_job(*argv, **kwargs):
 
                 print("            Resubmitting.")
 
-                if args["job_system"] == "slurm" or "TACC" or "UM-ARC":
+                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
                     job_list.append(helpers.run_bash_cmnd("sbatch run_vasp.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_vasp.cmd").replace('\n', ''))

--- a/src/vasp_driver.py
+++ b/src/vasp_driver.py
@@ -180,7 +180,7 @@ def continue_job(*argv, **kwargs):
 
                 print("            Resubmitting.")
 
-                if (args["job_system"] == "slurm" or args["job_system"] == "UM-ARC"):
+                if args["job_system"] == "slurm" or args["job_system"] == "TACC" or args["job_system"] == "UM-ARC":
                     job_list.append(helpers.run_bash_cmnd("sbatch run_vasp.cmd").split()[-1])
                 else:    
                     job_list.append(helpers.run_bash_cmnd("qsub run_vasp.cmd").replace('\n', ''))


### PR DESCRIPTION
This is fixing a bug introduced in #30
Updated the logic in all relevant files to ensure the conditionals for handling job systems properly check for 'slurm' or 'UM-ARC.' This prevents inadvertent, always-true conditions and ensures accurate execution flow based on the job system specified.

I also realized that the if statements we have for restarting QM jobs are wrong for TACC systems and probably all job so far on TACC have not faced this issue yet and we didn't see this bug. It was using qsub instead of sbatch when trying to restart a job.

These are tested on both TACC and UM-ARC on TACC I tested simple_iter_single_statepoint-cp2k and on UM-ARC I tested simple_bulk_MFI_cp2k