### PR TITLE
Add debug mode for reproducible MD seeds

### DIFF
--- a/src/chimes_run_md.py
+++ b/src/chimes_run_md.py
@@ -144,8 +144,8 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
     ### ...kwargs
     
-    default_keys   = [""]*16
-    default_values = [""]*16
+    default_keys   = [""]*17
+    default_values = [""]*17
 
     # MD specific controls
 

--- a/src/chimes_run_md.py
+++ b/src/chimes_run_md.py
@@ -149,11 +149,11 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
 
     # MD specific controls
 
-    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../CHIMES-MD_BASEFILES/"    # Directory containing run_md.base, etc.
-    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                           # Post_proc_lsq*py file... should also include the python command
-    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                        # Penalty function pre-factor
-    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                         # Pentaly function kick-in distance
-    default_keys[4 ] = "chimes_exe  "  ; default_values[4 ] = None                         # Unused by this function
+    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../CHIMES-MD_BASEFILES/"      # Directory containing run_md.base, etc.
+    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                             # Post_proc_lsq*py file... should also include the python command
+    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                          # Penalty function pre-factor
+    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                           # Pentaly function kick-in distance
+    default_keys[4 ] = "chimes_exe  "  ; default_values[4 ] = None                           # Unused by this function
     
     # Overall job controls
 
@@ -168,7 +168,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
-    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
+    default_keys[16] = "md_debug_mode" ; default_values[16] = False                          # Random seed or debug mode
 
 
     args = dict(list(zip(default_keys, default_values)))

--- a/src/chimes_run_md.py
+++ b/src/chimes_run_md.py
@@ -168,6 +168,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
+    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
 
 
     args = dict(list(zip(default_keys, default_values)))
@@ -242,7 +243,11 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
         if found1:
             #ofstream.write('\t' + str(1+my_indep) + str(1+my_indep) + str(1+my_indep) + str(1+my_indep) + '\n')
-            ofstream.write('\t' + str(random.randint(0,9999)) + '\n')
+            if not args["md_debug_mode"]: # If NOT in debug mode...
+                # Overwrite the seed with a random one
+                ofstream.write('\t' + str(random.randint(0,9999)) + '\n')
+            else: # If in debug mode, write the original line back
+                ofstream.write(runfile[i])
             found1 = False
         elif found2:
             ofstream.write('\t' + md_xyzfile + '\n')

--- a/src/dftbplus_run_md.py
+++ b/src/dftbplus_run_md.py
@@ -181,14 +181,15 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
 
     # MD specific controls
 
-    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../DFTB-MD_BASEFILES/"    # Directory containing run_md.base, etc.
-    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                         # Post_proc_lsq*py file... should also include the python command
-    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                      # Penalty function pre-factor
-    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                       # Pentaly function kick-in distance
-    default_keys[4 ] = "chimes_exe"    ; default_values[4 ] = None                       # Path to the ChIMES executable to be used - serial version preferred
+    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../DFTB-MD_BASEFILES/"        # Directory containing run_md.base, etc.
+    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                             # Post_proc_lsq*py file... should also include the python command
+    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                          # Penalty function pre-factor
+    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                           # Pentaly function kick-in distance
+    default_keys[4 ] = "chimes_exe"    ; default_values[4 ] = None                           # Path to the ChIMES executable to be used - serial version preferred
+    
     # Overall job controls
 
-    default_keys[5 ] = "job_name"      ; default_values[5 ] = "ALC-"+ repr(my_ALC)+"-md"    # Name for ChIMES md job
+    default_keys[5 ] = "job_name"      ; default_values[5 ] = "ALC-"+ repr(my_ALC)+"-md"     # Name for ChIMES md job
     default_keys[6 ] = "job_nodes"     ; default_values[6 ] = "1"                            # Number of nodes for ChIMES md job
     default_keys[7 ] = "job_ppn"       ; default_values[7 ] = "1"                            # Number of processors per node for ChIMES md job
     default_keys[8 ] = "job_walltime"  ; default_values[8 ] = "1"                            # Walltime in hours for ChIMES md job
@@ -196,10 +197,10 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[10] = "job_account"   ; default_values[10] = "pbronze"                      # Account for ChIMES md job
     default_keys[11] = "job_executable"; default_values[11] = ""                             # Full path to executable for ChIMES md job
     default_keys[12] = "job_system"    ; default_values[12] = "slurm"                        # slurm or torque    
-    default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                     # Name of the resulting submit script
+    default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
-    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
+    default_keys[16] = "md_debug_mode" ; default_values[16] = False                          # Random seed or debug mode
 
     args = dict(list(zip(default_keys, default_values)))
     args.update(kwargs)    

--- a/src/dftbplus_run_md.py
+++ b/src/dftbplus_run_md.py
@@ -176,8 +176,8 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
     ### ...kwargs
     
-    default_keys   = [""]*16
-    default_values = [""]*16
+    default_keys   = [""]*17
+    default_values = [""]*17
 
     # MD specific controls
 

--- a/src/dftbplus_run_md.py
+++ b/src/dftbplus_run_md.py
@@ -199,6 +199,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                     # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
+    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
 
     args = dict(list(zip(default_keys, default_values)))
     args.update(kwargs)    
@@ -273,11 +274,14 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
         
     for i in range(len(runfile)):
     
-        if "RandomSeed" in runfile[i]:
-            ofstream.write('  RandomSeed = ' + str(1+my_indep) + str(1+my_indep) + str(1+my_indep) + str(1+my_indep) + '\n')
+        # Check if the line contains the seed AND if we are NOT in debug mode
+        if "RandomSeed" in runfile[i] and not args["md_debug_mode"]:
+            # Overwrite with the original deterministic logic
+            ofstream.write('  RandomSeed = ' + str(1+my_indep) * 4 + '\n')
         elif "<<<" in runfile[i]:
             ofstream.write("<<<\" " + md_xyzfile + "\"\n")
         else:
+            # In debug mode or for any other line, write it as-is
             ofstream.write(runfile[i])
 
                 

--- a/src/lmp_run_md.py
+++ b/src/lmp_run_md.py
@@ -323,12 +323,12 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
 
     # MD specific controls
 
-    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../LMP-MD_BASEFILES/"    # Directory containing run_md.base, etc.
-    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                           # Post_proc_lsq*py file... should also include the python command
-    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                        # Penalty function pre-factor
-    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                         # Pentaly function kick-in distance
-    default_keys[4 ] = "chimes_exe"    ; default_values[4 ] = None                         # Unused by this function
-    default_keys[16] = "n_hyper_sets"  ; default_values[16] = 1                            # Number of unique fm_setup.in files; allows fitting, e.g., multiple overlapping models to the same data
+    default_keys[0 ] = "basefile_dir"  ; default_values[0 ] = "../LMP-MD_BASEFILES/"         # Directory containing run_md.base, etc.
+    default_keys[1 ] = "driver_dir"    ; default_values[1 ] = ""                             # Post_proc_lsq*py file... should also include the python command
+    default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                          # Penalty function pre-factor
+    default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                           # Pentaly function kick-in distance
+    default_keys[4 ] = "chimes_exe"    ; default_values[4 ] = None                           # Unused by this function
+    default_keys[16] = "n_hyper_sets"  ; default_values[16] = 1                              # Number of unique fm_setup.in files; allows fitting, e.g., multiple overlapping models to the same data
     
     # Overall job controls
 
@@ -343,7 +343,7 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
-    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
+    default_keys[17] = "md_debug_mode" ; default_values[17] = False                          # Random seed or debug mode
 
 
     args = dict(list(zip(default_keys, default_values)))

--- a/src/lmp_run_md.py
+++ b/src/lmp_run_md.py
@@ -318,8 +318,8 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     
     ### ...kwargs
     
-    default_keys   = [""]*17
-    default_values = [""]*17
+    default_keys   = [""]*18
+    default_values = [""]*18
 
     # MD specific controls
 
@@ -328,21 +328,21 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[2 ] = "penalty_pref"  ; default_values[2 ] = 1.0E6                          # Penalty function pre-factor
     default_keys[3 ] = "penalty_dist"  ; default_values[3 ] = 0.02                           # Pentaly function kick-in distance
     default_keys[4 ] = "chimes_exe"    ; default_values[4 ] = None                           # Unused by this function
-    default_keys[16] = "n_hyper_sets"  ; default_values[16] = 1                              # Number of unique fm_setup.in files; allows fitting, e.g., multiple overlapping models to the same data
+    default_keys[5 ] = "n_hyper_sets"  ; default_values[5 ] = 1                              # Number of unique fm_setup.in files; allows fitting, e.g., multiple overlapping models to the same data
     
     # Overall job controls
 
-    default_keys[5 ] = "job_name"      ; default_values[5 ] = "ALC-"+ repr(my_ALC)+"-md"     # Name for ChIMES md job
-    default_keys[6 ] = "job_nodes"     ; default_values[6 ] = "2"                            # Number of nodes for ChIMES md job
-    default_keys[7 ] = "job_ppn"       ; default_values[7 ] = "36"                           # Number of processors per node for ChIMES md job
-    default_keys[8 ] = "job_walltime"  ; default_values[8 ] = "1"                            # Walltime in hours for ChIMES md job
-    default_keys[9 ] = "job_queue"     ; default_values[9 ] = "pdebug"                       # Queue for ChIMES md job
-    default_keys[10] = "job_account"   ; default_values[10] = "pbronze"                      # Account for ChIMES md job
-    default_keys[11] = "job_executable"; default_values[11] = ""                             # Full path to executable for ChIMES md job
-    default_keys[12] = "job_system"    ; default_values[12] = "slurm"                        # slurm or torque    
-    default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
-    default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
-    default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
+    default_keys[6 ] = "job_name"      ; default_values[6 ] = "ALC-"+ repr(my_ALC)+"-md"     # Name for ChIMES md job
+    default_keys[7 ] = "job_nodes"     ; default_values[7 ] = "2"                            # Number of nodes for ChIMES md job
+    default_keys[8 ] = "job_ppn"       ; default_values[8 ] = "36"                           # Number of processors per node for ChIMES md job
+    default_keys[9 ] = "job_walltime"  ; default_values[9 ] = "1"                            # Walltime in hours for ChIMES md job
+    default_keys[10] = "job_queue"     ; default_values[10] = "pdebug"                       # Queue for ChIMES md job
+    default_keys[11] = "job_account"   ; default_values[11] = "pbronze"                      # Account for ChIMES md job
+    default_keys[12] = "job_executable"; default_values[12] = ""                             # Full path to executable for ChIMES md job
+    default_keys[13] = "job_system"    ; default_values[13] = "slurm"                        # slurm or torque    
+    default_keys[14] = "job_file"      ; default_values[14] = "run.cmd"                      # Name of the resulting submit script
+    default_keys[15] = "job_email"     ; default_values[15] = True                           # Send slurm emails?
+    default_keys[16] = "job_modules"   ; default_values[16] = ""                             # Send slurm emails?
     default_keys[17] = "md_debug_mode" ; default_values[17] = False                          # Random seed or debug mode
 
 

--- a/src/lmp_run_md.py
+++ b/src/lmp_run_md.py
@@ -343,6 +343,8 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
     default_keys[13] = "job_file"      ; default_values[13] = "run.cmd"                      # Name of the resulting submit script
     default_keys[14] = "job_email"     ; default_values[14] = True                           # Send slurm emails?
     default_keys[15] = "job_modules"   ; default_values[15] = ""                             # Send slurm emails?
+    default_keys.append("md_debug_mode"); default_values.append(False)                       # Random seed or debug mode
+
 
     args = dict(list(zip(default_keys, default_values)))
     args.update(kwargs)    
@@ -432,9 +434,12 @@ def run_md(my_ALC, my_case, my_indep, *argv, **kwargs):
         
         # Set seed (velocity all create)
     
-        if "seed equal" in runfile[i]:
-            ofstream.write("variable seed equal " + str(random.randint(0,9999)) + '\n')          
+        # Check if the line contains the seed AND if we are NOT in debug mode
+        if "seed equal" in runfile[i] and not args["md_debug_mode"]:
+            # Overwrite the seed with a random one
+            ofstream.write("variable seed equal " + str(random.randint(0,9999)) + '\n')
         else:
+            # In debug mode or for any other line, write it as-is
             ofstream.write(runfile[i])
                 
     ofstream.close()

--- a/src/main.py
+++ b/src/main.py
@@ -137,6 +137,8 @@ def main(args):
     
     verify_config.verify(config)
     
+    print(config.MD_DEBUG_MODE)
+
     print("The following has been set as the working directory:")
     print('\t', config.WORKING_DIR)
     print("The ALC-X contents of this directory will be overwritten.")
@@ -941,7 +943,8 @@ def main(args):
                         job_executable = config.MD_MPI,     
                         job_system     = config.HPC_SYSTEM,       
                         job_file       = "run.cmd",
-                        job_modules    = config.MD_MODULES
+                        job_modules    = config.MD_MODULES,
+                        md_debug_mode  = config.MD_DEBUG_MODE
                         )
                         
         

--- a/src/verify_config.py
+++ b/src/verify_config.py
@@ -1414,6 +1414,12 @@ def verify(user_config):
         print("       form of a NO_CASES long list, e.g. [\"4:00:00\"]*NO_CASES.")
         exit()
 
+    if not hasattr(user_config,'MD_DEBUG_MODE'):
+        # Add the abilitry to use the same seed for MD for debugging
+        print("WARNING: Option config.MD_DEBUG_MODE was not set.")
+        print("         Will use False (MD seeds will be random).")
+        user_config.MD_DEBUG_MODE = False
+
     ################################
     ##### Cluster specific paths/variables
     ################################

--- a/src/verify_config.py
+++ b/src/verify_config.py
@@ -1420,6 +1420,12 @@ def verify(user_config):
         print("         Will use False (MD seeds will be random).")
         user_config.MD_DEBUG_MODE = False
 
+    if user_config.MD_DEBUG_MODE:
+        print("INFO: MD_DEBUG_MODE set to True")
+        print("      Will preserve user-specified seeds in MD input files.")
+    else:
+        print("INFO: MD_DEBUG_MODE set to False")
+        print("      Will overwrite MD seeds with random values.")
     ################################
     ##### Cluster specific paths/variables
     ################################


### PR DESCRIPTION
Introduces an `MD_DEBUG_MODE` flag to enable reproducible MD runs for debugging purposes.

When this flag is set to `True`, the driver
preserves the seed specified in the user's base MD input file instead of overwriting it with a random value. This ensures deterministic trajectories, for debugging.

The flag defaults to `False` to maintain the standard stochastic behavior and backwards compatibility.

Now the simulation has nowhere to hide.

This was tested by running simple_bulk_MFI_cp2k example for 3 cycles and simple_bulk_MFI_cp2k with LAMMPS as the MD for 3 cycles, I also ran simple_iter_single_statepoint-lmp-test for a cycle without the ground truth portion.
