### PR TITLE
Fixed bug in genff, and updated fm_setup.in

### DIFF
--- a/examples/simple_iter_single_statepoint-lmp-test-turbo-test/ALL_BASE_FILES/ALC-0_BASEFILES/1.fm_setup.in
+++ b/examples/simple_iter_single_statepoint-lmp-test-turbo-test/ALL_BASE_FILES/ALC-0_BASEFILES/1.fm_setup.in
@@ -7,7 +7,7 @@
 # NFRAMES # 
         3001
 # NLAYERS #
-        1
+        2
 # FITCOUL #
         false
 # FITSTRS # 

--- a/examples/simple_iter_single_statepoint-lmp-test-turbo-test/ALL_BASE_FILES/LMPMD_BASEFILES/case-0.indep-0.in.lammps
+++ b/examples/simple_iter_single_statepoint-lmp-test-turbo-test/ALL_BASE_FILES/LMPMD_BASEFILES/case-0.indep-0.in.lammps
@@ -47,10 +47,10 @@ pair_coeff      * * chimesFF  2  1params.txt.reduced
 timestep        0.2
 
 fix             1 all nvt temp ${temp} ${temp} 20.0
-fix_modify      1 energy yes
+
 
 compute         ke_tensor all temp
-thermo_style    custom step time ke pe etotal temp press pxx pyy pzz pxy pxz pyz vol c_ke_tensor[1] c_ke_tensor[2] c_ke_tensor[3] c_ke_tensor[4] c_ke_tensor[5] c_ke_tensor[6]
+thermo_style    custom step time ke pe econserve temp press pxx pyy pzz pxy pxz pyz vol c_ke_tensor[1] c_ke_tensor[2] c_ke_tensor[3] c_ke_tensor[4] c_ke_tensor[5] c_ke_tensor[6]
 thermo_modify   line one format float %20.5f flush yes
 thermo          ${iofrq}
 

--- a/examples/simple_iter_single_statepoint-lmp-test/ALL_BASE_FILES/LMPMD_BASEFILES/case-0.indep-0.in.lammps
+++ b/examples/simple_iter_single_statepoint-lmp-test/ALL_BASE_FILES/LMPMD_BASEFILES/case-0.indep-0.in.lammps
@@ -48,10 +48,9 @@ pair_coeff      * * params.txt.reduced
 timestep        0.2
 
 fix             1 all nvt temp ${temp} ${temp} 20.0
-fix_modify      1 energy yes
 
 compute         ke_tensor all temp
-thermo_style    custom step time ke pe etotal temp press pxx pyy pzz pxy pxz pyz vol c_ke_tensor[1] c_ke_tensor[2] c_ke_tensor[3] c_ke_tensor[4] c_ke_tensor[5] c_ke_tensor[6]
+thermo_style    custom step time ke pe econserve temp press pxx pyy pzz pxy pxz pyz vol c_ke_tensor[1] c_ke_tensor[2] c_ke_tensor[3] c_ke_tensor[4] c_ke_tensor[5] c_ke_tensor[6]
 thermo_modify   line one format float %20.5f flush yes
 thermo          ${iofrq}
 

--- a/src/gen_ff.py
+++ b/src/gen_ff.py
@@ -792,16 +792,13 @@ def build_amat(my_ALC, **kwargs):
             ifstream = open(GEN_FF + "/fm_setup.in",'r')
             runfile  = ifstream.readlines()
 
-            found1=False
             for i in range(len(runfile)): # This loop is to make sure that split files is false
-                if found1:
-                    if "true" in runfile[i]:
+                if "SPLITFI" in runfile[i]:
+                    if i + 1 < len(runfile) and "true" in runfile[i + 1]:
                         print("Error: This driver does NOT support SPLITFI functionality in fm_setup.in")
                         print("Exiting.")
                         exit()
-                    found1=False
-                if "SPLITFI" in runfile[i]: 
-                    found1=True
+                    break
                 
             if len(glob.glob(args["prev_gen_path"] + "/*xyzf"  )) > 0:
                 helpers.run_bash_cmnd("cp " + ' '.join(glob.glob(args["prev_gen_path"] + "/*xyzf"  )) + " " + GEN_FF + "/")
@@ -916,7 +913,8 @@ def build_amat(my_ALC, **kwargs):
                         
                         exit()
                     else:
-                        ofstream.write(runfile[i])    
+                        ofstream.write(runfile[i])
+                    found4 = False
                 else:
     
                     ofstream.write(runfile[i])

--- a/src/gen_ff.py
+++ b/src/gen_ff.py
@@ -799,6 +799,7 @@ def build_amat(my_ALC, **kwargs):
                         print("Error: This driver does NOT support SPLITFI functionality in fm_setup.in")
                         print("Exiting.")
                         exit()
+                    found1=False
                 if "SPLITFI" in runfile[i]: 
                     found1=True
                 

--- a/src/gen_ff.py
+++ b/src/gen_ff.py
@@ -792,13 +792,17 @@ def build_amat(my_ALC, **kwargs):
             ifstream = open(GEN_FF + "/fm_setup.in",'r')
             runfile  = ifstream.readlines()
 
+            found1=False
             for i in range(len(runfile)): # This loop is to make sure that split files is false
-                if "SPLITFI" in runfile[i]:
-                    if i + 1 < len(runfile) and "true" in runfile[i + 1]:
+                if found1:
+                    if "true" in runfile[i]:
                         print("Error: This driver does NOT support SPLITFI functionality in fm_setup.in")
                         print("Exiting.")
                         exit()
-                    break
+                    else:
+                        break
+                if "SPLITFI" in runfile[i]: 
+                    found1=True
                 
             if len(glob.glob(args["prev_gen_path"] + "/*xyzf"  )) > 0:
                 helpers.run_bash_cmnd("cp " + ' '.join(glob.glob(args["prev_gen_path"] + "/*xyzf"  )) + " " + GEN_FF + "/")
@@ -867,7 +871,6 @@ def build_amat(my_ALC, **kwargs):
             found1 = False
             found2 = False
             found3 = False
-            found4 = False
     
             for i in range(len(runfile)):
     
@@ -906,15 +909,7 @@ def build_amat(my_ALC, **kwargs):
                         ofstream.write('\t' + "false" + '\n')
             
                     found3 = False
-                elif found4:
-                    if "true" in runfile[i]:
-                        print("Error: This driver does NOT support SPLITFI functionality in fm_setup.in")
-                        print("Exiting.")
-                        
-                        exit()
-                    else:
-                        ofstream.write(runfile[i])
-                    found4 = False
+  
                 else:
     
                     ofstream.write(runfile[i])


### PR DESCRIPTION
# Pull Request Description

This PR includes fixes related to both the TurboChIMES test case long-range setup and the SPLITFI parsing logic.

## TurboChIMES Test Case / Neighbor Binning Fix

The following error was observed during long-range TurboChIMES calculations:

```text id="j7mf39"
Error: out of range binning BIN_IDX for atom a1 = 1342
Atom has coordinates: 29.5479, -4.055, -12.99419
Atom has bins:        6 1 0
Max bins: 6 7 7
Check box lengths in .xyz* file.
```

To address this, a small modification was made to the `fm_setup.in` file. Specifically, `NLAYERS` was increased from `1` to `2`.

An `S_MAXIM` value of `7 Å` requires ghost atoms that extend farther from the primary simulation cell than a single ghost layer can accommodate. With `NLAYERS = 1`, the effective extended domain is only about `45 Å` (corresponding to one periodic image shell). Since ghost wrapping is disabled, one of the periodic neighbor images in frame `2063` appears at approximately `z ≈ -13 Å`, which falls outside the spatial bin grid constructed for that domain. This causes the atom to be excluded from valid neighbor binning.

The padding in the previous implementation prevented this issue from being detected earlier.

Fixes a false-positive SPLITFI validation error in build_amat() that caused hierarchical-fit workflows to exit even when # SPLITFI # was set to false.

##  SPLITFI Bug
The driver validates fm_setup.in by scanning for the # SPLITFI # keyword and checking whether the next line contains true. The original implementation used a persistent flag (found1 for ALC 0/1, found4 for ALC ≥ 2) meaning “the next line is the SPLITFI value.”

After reading false on that line, the flag was never cleared, so every subsequent line in the file was still treated as the SPLITFI value. Hierarchical fm_setup.in files (as documented in hierarchmode.rst) include:

## SPLITFI #
        false
##  HIERARC #
        true
When the parser reached # HIERARC # >> true, it incorrectly concluded that SPLITFI was enabled and exited with:

Error: This driver does NOT support SPLITFI functionality in fm_setup.in
This was not a misconfigured base file, SPLITFI was correctly false. The validation logic was wrong.

Where it showed up
Code path	When	Original issue
ALC 0 / ALC 1 (non-cluster)
Copy fm_setup.in from base files
found1 never reset after SPLITFI check
ALC ≥ 2
Rewrite fm_setup.in (update NFRAMES, FITSTRS, etc.)
found4 never reset after SPLITFI check
ALC 1 could pass after the first fix, then ALC 2 would fail on the second code path with the same error.

Fix
ALC 0 / ALC 1 :explicit check + break
Replaced the flag-based loop with a direct, one-shot check:

for i in range(len(runfile)):
    if "SPLITFI" in runfile[i]:
        if i + 1 < len(runfile) and "true" in runfile[i + 1]:
            print("Error: This driver does NOT support SPLITFI functionality in fm_setup.in")
            print("Exiting.")
            exit()
        break
Why break: The loop only needs to answer one question, is the line immediately after # SPLITFI # set to true? Once that line is checked, there is nothing else to validate, so the loop stops. This avoids stale state and makes the intent explicit: check SPLITFI once, then continue.

ALC ≥ 2, reset found4 after handling SPLITFI
The ALC ≥ 2 path still uses found1/found2/found3/found4 because it rewrites the lines after # TRJFILE #, # NFRAMES #, and # FITSTRS #. found4 does not rewrite SPLITFI, it only validates and passes the value through, but it lives in the same state-machine loop.

The fix adds found4 = False after the SPLITFI value line is handled (matching how found1–found3 are already cleared), so later true values (e.g. HIERARC) are not misread.

This PR also includes updates to the lammps input script, given that the new lammps does not require the fix modify energy command.


